### PR TITLE
Onboarding mechanic, registration, login, logout

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,18 +25,19 @@ class YoursApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: _title,
       home: FutureBuilder<bool>(
-          future: showOnboardingPage(),
-          builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              // I **KNOW** that this looks stupid af, but you can't use snapshot.data as a conditional for null safety
-              if (snapshot.data != false) {
-                return const OnboardingPage(); // go to onboarding page
-              }
-              return const HomePages(); // TODO goes to home now but make it go to login later
-            } else {
-              return const SplashScreen();
+        future: showOnboardingPage(),
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            // I **KNOW** that this looks stupid af, but you can't use snapshot.data as a conditional for null safety
+            if (snapshot.data != false) {
+              return const OnboardingPage(); // go to onboarding page
             }
-          }),
+            return const HomePages(); // TODO goes to home now but make it go to login later
+          } else {
+            return const SplashScreen();
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'pages/HomePages.dart';
+import 'pages/LoginForm.dart';
 import 'pages/OnboardingPage.dart';
 import 'pages/SplashScreen.dart';
 
@@ -32,7 +32,7 @@ class YoursApp extends StatelessWidget {
             if (snapshot.data != false) {
               return const OnboardingPage(); // go to onboarding page
             }
-            return const HomePages(); // TODO goes to home now but make it go to login later
+            return const LoginPage();
           } else {
             return const SplashScreen();
           }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,21 +29,24 @@ class YoursApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: _title,
-      home: FutureBuilder<bool>(
-        future: showOnboardingPage(),
-        builder: (context, snapshot) {
-          if (snapshot.hasData) {
-            if (snapshot.data as bool) {
-              return const OnboardingPage();
-            }
-            return const LoginForm(isError: false);
-          } else {
-            return const SplashScreen();
-          }
-        },
-      ),
-    );
+        debugShowCheckedModeBanner: false,
+        title: _title,
+        home: LoadingPage(
+          future: () => showOnboardingPage(),
+          handleFinished: (Object data) {
+            return data as bool
+                ? const OnboardingPage()
+                : const LoginForm(isError: false);
+          },
+        ));
   }
 }
+
+/*
+LoadingPage(
+  future: () => showOnboardingPage(),
+  handleFinished: (Object data) {
+    return const (snapshot.data as bool ? OnboardingPage() : LoginForm(isError: false);
+  },
+)
+*/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'pages/HomePages.dart';
+import 'pages/OnboardingPage.dart';
 import 'pages/SplashScreen.dart';
-import 'pages/CalendarTab.dart';
-import 'pages/SettingsTab.dart';
-import 'pages/InsightsTab.dart';
 
 Future<bool> showOnboardingPage() async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -31,76 +30,13 @@ class YoursApp extends StatelessWidget {
             if (snapshot.hasData) {
               // I **KNOW** that this looks stupid af, but you can't use snapshot.data as a conditional for null safety
               if (snapshot.data != false) {
-                return Container(color: Colors.green); // go to onboarding page
+                return const OnboardingPage(); // go to onboarding page
               }
               return const HomePages(); // TODO goes to home now but make it go to login later
             } else {
               return const SplashScreen();
             }
           }),
-    );
-  }
-}
-
-class HomePages extends StatefulWidget {
-  const HomePages({Key? key}) : super(key: key);
-
-  @override
-  State<HomePages> createState() => _HomePagesState();
-}
-
-class _HomePagesState extends State<HomePages> {
-  int _tabIndex = 0;
-
-  static const List<Widget> _tabContent = <Widget>[
-    CalendarTab(),
-    InsightsTab(),
-    SettingsTab(),
-  ];
-
-  void _onTabTapped(int index) {
-    setState(() {
-      _tabIndex = index;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: _tabIndex == 2
-          ? AppBar(
-              title: const Text(
-                'Settings',
-                style: TextStyle(color: Colors.white),
-              ),
-              centerTitle: true,
-              backgroundColor: Colors.black,
-            )
-          : null,
-      body: Center(
-        child: _tabContent.elementAt(_tabIndex),
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: Colors.black,
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.calendar_month),
-            label: 'Calendar',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.lightbulb),
-            label: 'Insights',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.settings),
-            label: 'Settings',
-          ),
-        ],
-        currentIndex: _tabIndex,
-        selectedItemColor: Colors.red,
-        unselectedItemColor: Colors.white,
-        onTap: _onTabTapped,
-      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,9 +35,8 @@ class YoursApp extends StatelessWidget {
         future: showOnboardingPage(),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
-            // I **KNOW** that this looks stupid af, but you can't use snapshot.data as a conditional for null safety
-            if (snapshot.data != false) {
-              return const OnboardingPage(); // go to onboarding page
+            if (snapshot.data as bool) {
+              return const OnboardingPage();
             }
             return const LoginPage(isError: false);
           } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,7 @@ class YoursApp extends StatelessWidget {
             if (snapshot.data != false) {
               return const OnboardingPage(); // go to onboarding page
             }
-            return const LoginPage();
+            return const LoginPage(isError: false);
           } else {
             return const SplashScreen();
           }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'pages/LoginForm.dart';
 import 'pages/OnboardingPage.dart';
@@ -10,7 +12,12 @@ Future<bool> showOnboardingPage() async {
   return (seenOnboarding == null || !seenOnboarding);
 }
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final appDocumentDirectory = await getApplicationDocumentsDirectory();
+  Hive.init(appDocumentDirectory.path);
+
   runApp(const YoursApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'pages/SplashScreen.dart';
 import 'pages/CalendarTab.dart';
 import 'pages/SettingsTab.dart';
 import 'pages/InsightsTab.dart';
+
+Future<bool> showOnboardingPage() async {
+  SharedPreferences prefs = await SharedPreferences.getInstance();
+  bool? seenOnboarding = prefs.getBool('onboarded');
+  return (seenOnboarding == null || !seenOnboarding);
+}
 
 void main() {
   runApp(const YoursApp());
@@ -14,10 +22,22 @@ class YoursApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: _title,
-      home: HomePages(),
+      home: FutureBuilder<bool>(
+          future: showOnboardingPage(),
+          builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              // I **KNOW** that this looks stupid af, but you can't use snapshot.data as a conditional for null safety
+              if (snapshot.data != false) {
+                return Container(color: Colors.green); // go to onboarding page
+              }
+              return const HomePages(); // TODO goes to home now but make it go to login later
+            } else {
+              return const SplashScreen();
+            }
+          }),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,12 +41,3 @@ class YoursApp extends StatelessWidget {
         ));
   }
 }
-
-/*
-LoadingPage(
-  future: () => showOnboardingPage(),
-  handleFinished: (Object data) {
-    return const (snapshot.data as bool ? OnboardingPage() : LoginForm(isError: false);
-  },
-)
-*/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,7 @@ class YoursApp extends StatelessWidget {
             if (snapshot.data as bool) {
               return const OnboardingPage();
             }
-            return const LoginPage(isError: false);
+            return const LoginForm(isError: false);
           } else {
             return const SplashScreen();
           }

--- a/lib/pages/HomePages.dart
+++ b/lib/pages/HomePages.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import 'CalendarTab.dart';
+import 'InsightsTab.dart';
+import 'SettingsTab.dart';
+
+class HomePages extends StatefulWidget {
+  const HomePages({Key? key}) : super(key: key);
+
+  @override
+  State<HomePages> createState() => _HomePagesState();
+}
+
+class _HomePagesState extends State<HomePages> {
+  int _tabIndex = 0;
+
+  static const List<Widget> _tabContent = <Widget>[
+    CalendarTab(),
+    InsightsTab(),
+    SettingsTab(),
+  ];
+
+  void _onTabTapped(int index) {
+    setState(() {
+      _tabIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _tabIndex == 2
+          ? AppBar(
+              title: const Text(
+                'Settings',
+                style: TextStyle(color: Colors.white),
+              ),
+              centerTitle: true,
+              backgroundColor: Colors.black,
+            )
+          : null,
+      body: Center(
+        child: _tabContent.elementAt(_tabIndex),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        backgroundColor: Colors.black,
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_month),
+            label: 'Calendar',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.lightbulb),
+            label: 'Insights',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
+        currentIndex: _tabIndex,
+        selectedItemColor: Colors.red,
+        unselectedItemColor: Colors.white,
+        onTap: _onTabTapped,
+      ),
+    );
+  }
+}

--- a/lib/pages/HomePages.dart
+++ b/lib/pages/HomePages.dart
@@ -5,7 +5,9 @@ import 'InsightsTab.dart';
 import 'SettingsTab.dart';
 
 class HomePages extends StatefulWidget {
-  const HomePages({Key? key}) : super(key: key);
+  final String sqlKey;
+
+  const HomePages({Key? key, required this.sqlKey}) : super(key: key);
 
   @override
   State<HomePages> createState() => _HomePagesState();

--- a/lib/pages/HomePages.dart
+++ b/lib/pages/HomePages.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
 
 import 'CalendarTab.dart';
 import 'InsightsTab.dart';
 import 'SettingsTab.dart';
 
 class HomePages extends StatefulWidget {
-  final String sqlKey;
+  final Box calendarBox;
 
-  const HomePages({Key? key, required this.sqlKey}) : super(key: key);
+  const HomePages({Key? key, required this.calendarBox}) : super(key: key);
 
   @override
   State<HomePages> createState() => _HomePagesState();

--- a/lib/pages/HomePages.dart
+++ b/lib/pages/HomePages.dart
@@ -15,11 +15,11 @@ class HomePages extends StatefulWidget {
 }
 
 class _HomePagesState extends State<HomePages> {
-  int _tabIndex = 0;
+  int _tabIndex = 1;
 
   static const List<Widget> _tabContent = <Widget>[
-    CalendarTab(),
     InsightsTab(),
+    CalendarTab(),
     SettingsTab(),
   ];
 
@@ -49,12 +49,12 @@ class _HomePagesState extends State<HomePages> {
         backgroundColor: Colors.black,
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: Icon(Icons.calendar_month),
-            label: 'Calendar',
-          ),
-          BottomNavigationBarItem(
             icon: Icon(Icons.lightbulb),
             label: 'Insights',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_month),
+            label: 'Calendar',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.settings),

--- a/lib/pages/LoginForm.dart
+++ b/lib/pages/LoginForm.dart
@@ -1,0 +1,156 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:convert/convert.dart';
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'SplashScreen.dart';
+import 'HomePages.dart';
+
+class LoginLoadingPage extends StatefulWidget {
+  final String pin;
+
+  const LoginLoadingPage({Key? key, required this.pin}) : super(key: key);
+
+  @override
+  State<LoginLoadingPage> createState() => _LoginLoadingPageState();
+}
+
+class _LoginLoadingPageState extends State<LoginLoadingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: _checkPinHash(widget.pin),
+      builder: (context, snapshot) {
+        if(snapshot.data == null) {
+          return const SplashScreen();
+        } else if(snapshot.data == true) {
+          return const HomePages();
+        } else {
+          return Container(color: Colors.red,);
+        }
+      },
+    );
+  }
+}
+
+void _submitLogin(GlobalKey<FormState> key, BuildContext context, String pin) {
+  if (key.currentState!.validate()) {
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => LoginLoadingPage(pin: pin)),
+      (route) => false,
+    );
+  }
+}
+
+Future<String> _calculatePinHash (HashMap values) async {
+  final SecretKey pinBytes = SecretKey(utf8.encode(values["pin"]));
+
+  final pdkdf2 = Pbkdf2(
+    macAlgorithm: Hmac.sha512(),
+    iterations: 150000,
+    bits: 256,
+  );
+
+  final salt = SecretKey(hex.decode(values["salt"]));
+
+  final pinKey = await pdkdf2.deriveKey(
+    secretKey: pinBytes,
+    nonce: await salt.extractBytes(),
+  );
+
+  final sha512 = Sha512();
+  final hashedPinKey = await sha512.hash(await pinKey.extractBytes());
+
+  return hex.encode(hashedPinKey.bytes);
+}
+
+// returns true if match, false if not
+Future<bool> _checkPinHash(String pin) async {
+  SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  HashMap values = HashMap();
+  values["pin"] = pin;
+  values["salt"] = prefs.getString("salt")!;
+
+  final hashedPinKey = await compute(_calculatePinHash, values);
+  final storedHashedUserKey = prefs.getString("hashedUserKey")!;
+
+  final result = hashedPinKey == storedHashedUserKey;
+
+  return result;
+}
+
+class LoginForm extends StatefulWidget {
+  const LoginForm({Key? key}) : super(key: key);
+
+  @override
+  State<LoginForm> createState() => _LoginFormState();
+}
+
+class _LoginFormState extends State<LoginForm> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _pin = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const Text(
+              "Enter PIN",
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            TextFormField(
+              controller: _pin,
+              autocorrect: false,
+              enableSuggestions: false,
+              enableIMEPersonalizedLearning: false,
+              obscureText: true,
+              autofocus: true,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter your PIN';
+                }
+                return null;
+              },
+              textInputAction: TextInputAction.go,
+              onFieldSubmitted: (value) {
+                _submitLogin(_formKey, context, _pin.text);
+              },
+            ),
+            ElevatedButton(
+              onPressed: () {
+                _submitLogin(_formKey, context, _pin.text);
+              },
+              child: const Text('Log In'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: LoginForm(),
+    );
+  }
+}

--- a/lib/pages/LoginForm.dart
+++ b/lib/pages/LoginForm.dart
@@ -13,7 +13,6 @@ import 'HomePages.dart';
 void _submitLogin(GlobalKey<FormState> key, BuildContext context, String pin) {
   if (key.currentState!.validate()) {
     Navigator.of(context).pushAndRemoveUntil(
-      // MaterialPageRoute(builder: (_) => LoginLoadingPage(pin: pin)),
       MaterialPageRoute(
           builder: (_) => LoadingPage(
                 future: () => _checkPinHash(pin),
@@ -132,16 +131,12 @@ class _LoginFormState extends State<LoginForm> {
                 enableIMEPersonalizedLearning: false,
                 obscureText: true,
                 autofocus: true,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter your PIN';
-                  }
-                  return null;
-                },
+                validator: (value) => value == null || value.isEmpty
+                    ? 'Please enter your PIN'
+                    : null,
                 textInputAction: TextInputAction.go,
-                onFieldSubmitted: (value) {
-                  _submitLogin(_formKey, context, _pin.text);
-                },
+                onFieldSubmitted: (value) =>
+                    _submitLogin(_formKey, context, _pin.text),
                 decoration: InputDecoration(
                   errorText: widget.isError
                       ? "Incorrect PIN. Please try again."
@@ -149,9 +144,7 @@ class _LoginFormState extends State<LoginForm> {
                 ),
               ),
               ElevatedButton(
-                onPressed: () {
-                  _submitLogin(_formKey, context, _pin.text);
-                },
+                onPressed: () => _submitLogin(_formKey, context, _pin.text),
                 child: const Text('Log In'),
               )
             ],

--- a/lib/pages/LoginForm.dart
+++ b/lib/pages/LoginForm.dart
@@ -29,7 +29,7 @@ class _LoginLoadingPageState extends State<LoginLoadingPage> {
         } else if(snapshot.data == true) {
           return const HomePages();
         } else {
-          return Container(color: Colors.red,);
+          return const LoginPage(isError: true);
         }
       },
     );
@@ -84,7 +84,9 @@ Future<bool> _checkPinHash(String pin) async {
 }
 
 class LoginForm extends StatefulWidget {
-  const LoginForm({Key? key}) : super(key: key);
+  final bool isError;
+
+  const LoginForm({Key? key, required this.isError}) : super(key: key);
 
   @override
   State<LoginForm> createState() => _LoginFormState();
@@ -125,6 +127,9 @@ class _LoginFormState extends State<LoginForm> {
               onFieldSubmitted: (value) {
                 _submitLogin(_formKey, context, _pin.text);
               },
+              decoration: InputDecoration(
+                errorText: widget.isError ? "Incorrect PIN. Please try again." : null,
+              ),
             ),
             ElevatedButton(
               onPressed: () {
@@ -140,7 +145,9 @@ class _LoginFormState extends State<LoginForm> {
 }
 
 class LoginPage extends StatefulWidget {
-  const LoginPage({Key? key}) : super(key: key);
+  final bool isError;
+
+  const LoginPage({Key? key, required this.isError}) : super(key: key);
 
   @override
   State<LoginPage> createState() => _LoginPageState();
@@ -149,8 +156,8 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: LoginForm(),
+    return Scaffold(
+      body: LoginForm(isError: widget.isError),
     );
   }
 }

--- a/lib/pages/LoginForm.dart
+++ b/lib/pages/LoginForm.dart
@@ -26,7 +26,7 @@ class _LoginLoadingPageState extends State<LoginLoadingPage> {
       future: _checkPinHash(widget.pin),
       builder: (context, snapshot) {
         if(snapshot.data is Error){
-          return const LoginPage(isError: true);
+          return const LoginForm(isError: true);
         } else if(snapshot.data == null) {
           return const SplashScreen();
         } else {
@@ -126,66 +126,50 @@ class _LoginFormState extends State<LoginForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: _formKey,
-      child: Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            const Text(
-              "Enter PIN",
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            TextFormField(
-              controller: _pin,
-              autocorrect: false,
-              enableSuggestions: false,
-              enableIMEPersonalizedLearning: false,
-              obscureText: true,
-              autofocus: true,
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter your PIN';
-                }
-                return null;
-              },
-              textInputAction: TextInputAction.go,
-              onFieldSubmitted: (value) {
-                _submitLogin(_formKey, context, _pin.text);
-              },
-              decoration: InputDecoration(
-                errorText: widget.isError ? "Incorrect PIN. Please try again." : null,
+    return Scaffold(
+      body: Form(
+        key: _formKey,
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                "Enter PIN",
+                style: TextStyle(fontWeight: FontWeight.bold),
               ),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                _submitLogin(_formKey, context, _pin.text);
-              },
-              child: const Text('Log In'),
-            )
-          ],
+              TextFormField(
+                controller: _pin,
+                autocorrect: false,
+                enableSuggestions: false,
+                enableIMEPersonalizedLearning: false,
+                obscureText: true,
+                autofocus: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your PIN';
+                  }
+                  return null;
+                },
+                textInputAction: TextInputAction.go,
+                onFieldSubmitted: (value) {
+                  _submitLogin(_formKey, context, _pin.text);
+                },
+                decoration: InputDecoration(
+                  errorText: widget.isError ? "Incorrect PIN. Please try again." : null,
+                ),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  _submitLogin(_formKey, context, _pin.text);
+                },
+                child: const Text('Log In'),
+              )
+            ],
+          ),
         ),
       ),
-    );
-  }
-}
-
-class LoginPage extends StatefulWidget {
-  final bool isError;
-
-  const LoginPage({Key? key, required this.isError}) : super(key: key);
-
-  @override
-  State<LoginPage> createState() => _LoginPageState();
-}
-
-class _LoginPageState extends State<LoginPage> {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: LoginForm(isError: widget.isError),
     );
   }
 }

--- a/lib/pages/LoginForm.dart
+++ b/lib/pages/LoginForm.dart
@@ -83,7 +83,7 @@ Future<String> _getRandKey(HashMap inputs) async {
   return hex.encode(await loginAES.decrypt(storedBox, secretKey: inputs["userKey"]));
 }
 
-// returns true if match, false if not
+// returns box if match, Error if not
 Future<dynamic> _checkPinHash(String pin) async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
 

--- a/lib/pages/OnboardingPage.dart
+++ b/lib/pages/OnboardingPage.dart
@@ -11,13 +11,6 @@ class OnboardingPage extends StatefulWidget {
 
 class _OnboardingPageState extends State<OnboardingPage> {
   void _onOnboardingEnd(context) {
-    /*Navigator.of(context).pushAndRemoveUntil(
-      MaterialPageRoute<void>(
-        builder: (_) => const HomePages(), // TODO this is going to home rn but switch this to the reg screen
-      ),
-      (route) => false,
-    );*/
-
     Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/pages/OnboardingPage.dart
+++ b/lib/pages/OnboardingPage.dart
@@ -14,7 +14,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (_) => const RegistrationPage(),
+        builder: (_) => const RegistrationForm(),
       ),
     );
   }

--- a/lib/pages/OnboardingPage.dart
+++ b/lib/pages/OnboardingPage.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:introduction_screen/introduction_screen.dart';
-import 'HomePages.dart';
+import 'RegistrationForm.dart';
 
 class OnboardingPage extends StatefulWidget {
   const OnboardingPage({Key? key}) : super(key: key);
@@ -11,11 +11,18 @@ class OnboardingPage extends StatefulWidget {
 
 class _OnboardingPageState extends State<OnboardingPage> {
   void _onOnboardingEnd(context) {
-    Navigator.of(context).pushAndRemoveUntil(
+    /*Navigator.of(context).pushAndRemoveUntil(
       MaterialPageRoute<void>(
         builder: (_) => const HomePages(), // TODO this is going to home rn but switch this to the reg screen
       ),
       (route) => false,
+    );*/
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => const RegistrationPage(),
+      ),
     );
   }
 

--- a/lib/pages/OnboardingPage.dart
+++ b/lib/pages/OnboardingPage.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:introduction_screen/introduction_screen.dart';
+import 'HomePages.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({Key? key}) : super(key: key);
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  void _onOnboardingEnd(context) {
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute<void>(
+        builder: (_) => const HomePages(), // TODO this is going to home rn but switch this to the reg screen
+      ),
+      (route) => false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IntroductionScreen(
+      pages: [
+        PageViewModel(
+          titleWidget: RichText(
+            textAlign: TextAlign.center,
+            text: TextSpan(
+              style: TextStyle(
+                  color: Colors.black,
+                  fontSize: DefaultTextStyle.of(context).style.fontSize),
+              children: <TextSpan>[
+                const TextSpan(text: 'Welcome to\n'),
+                TextSpan(
+                    text: 'yours',
+                    style: TextStyle(
+                        fontStyle: FontStyle.italic,
+                        color: Colors.red.shade500)),
+                const TextSpan(text: '.')
+              ],
+            ),
+          ),
+          body: "The only security-first period-tracking app.",
+          image: Center(
+            child: Text(
+              // TODO replace with logo
+              "logo",
+              style: TextStyle(
+                color: Colors.red.shade400,
+                fontWeight: FontWeight.bold,
+                fontStyle: FontStyle.italic,
+                fontSize: DefaultTextStyle.of(context)
+                    .style
+                    .apply(fontSizeFactor: 2.0)
+                    .fontSize,
+              ),
+            ),
+          ),
+          reverse: false,
+        ),
+        PageViewModel(body: "#2", title: "Page placeholder"),
+        PageViewModel(body: "#3", title: "Page placeholder"),
+        PageViewModel(body: "#4", title: "Page placeholder"),
+        PageViewModel(body: "#5", title: "Page placeholder"),
+      ],
+      onDone: () => _onOnboardingEnd(context),
+      done: Text("Get Started", style: TextStyle(color: Colors.red.shade500),),
+      next: Icon(Icons.arrow_forward, color: Colors.red.shade500,),
+      isProgressTap: false,
+      dotsDecorator: DotsDecorator(
+        activeColor: Colors.red.shade500,
+        activeSize: const Size(18.0, 9.0),
+        activeShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
+      ),
+    );
+  }
+}

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -60,7 +60,7 @@ Future<Map> _calculateEncryptionValues(String pin) async {
   return values;
 }
 
-Future<bool> _registerPIN(String pin) async {
+Future<String> _registerPIN(String pin) async {
   final encryptionValues = await compute(_calculateEncryptionValues, pin);
   SharedPreferences prefs = await SharedPreferences.getInstance();
 
@@ -75,56 +75,8 @@ Future<bool> _registerPIN(String pin) async {
   prefs.setString("randKeyMAC", encryptionValues["randKeyMAC"]);
 
   prefs.setBool("onboarded", true);
-  /* --------------------- */
-  // this section is simulating a user login. TESTING ONLY! REMOVE LATER!
-  /*String userEnteredPin = "test";
 
-  final loginKeyGen = Pbkdf2(
-    macAlgorithm: Hmac.sha512(),
-    iterations: 200000,
-    bits: 256,
-  );
-
-  final SecretKey loginPinBytes = SecretKey(utf8.encode(pin));
-
-  final String loginSaltString = prefs.getString("salt").toString();
-  final SecretKey loginSalt = SecretKey(hex.decode(loginSaltString));
-
-  final loginUserKey = await loginKeyGen.deriveKey(
-    secretKey: loginPinBytes,
-    nonce: await loginSalt.extractBytes(),
-  );
-
-  final loginSha512 = Sha512();
-  final loginHashedUserKey =
-      await loginSha512.hash(await loginUserKey.extractBytes());
-  final storedHashedUserKey = prefs.getString("hashedUserKey").toString();
-
-  assert(hex.encode(loginHashedUserKey.bytes).hashCode ==
-      storedHashedUserKey.hashCode);
-
-  final storedRandKeyCipherText =
-      hex.decode(prefs.getString("randKeyCipherText").toString());
-  final storedRandKeyNonce =
-      hex.decode(prefs.getString("randKeyNonce").toString());
-  final storedRandKeyMAC = hex.decode(prefs.getString("randKeyMAC").toString());
-
-  final storedBox = SecretBox(
-    storedRandKeyCipherText,
-    nonce: storedRandKeyNonce,
-    mac: Mac(storedRandKeyMAC),
-  );
-
-  final loginAES = AesGcm.with256bits();
-
-  final clearText = await loginAES.decrypt(storedBox, secretKey: loginUserKey);
-  final clearTextStr = hex.encode(clearText);
-  assert(clearTextStr.hashCode == randKeyBytesHexStr.hashCode);*/
-  /* --------------------- */
-
-  //await Future.delayed(const Duration(seconds: 5));
-
-  return true;
+  return encryptionValues["randKey"];
 }
 
 class RegistrationLoadingPage extends StatefulWidget {
@@ -147,7 +99,7 @@ class _RegistrationLoadingPageState extends State<RegistrationLoadingPage> {
         if (snapshot.data == null) {
           return const SplashScreen();
         } else {
-          return const HomePages();
+          return HomePages(sqlKey: snapshot.data.toString());
         }
       },
     );

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -14,13 +14,11 @@ import 'SplashScreen.dart';
 Future<Map> _calculateEncryptionValues(String pin) async {
   HashMap values = HashMap();
 
-  // this should give us 256 bits? someone check my math
   final SecretKey randKey = SecretKey(
       List<int>.generate(32, (index) => Random.secure().nextInt(255)));
   final List<int> randKeyBytes = await randKey.extractBytes();
   values.putIfAbsent("randKey", () => randKeyBytes);
 
-  // utf8 or ascii here? I guess utf8 gives us a bigger PIN space?
   final SecretKey pinBytes = SecretKey(utf8.encode(pin));
 
   final pbkdf2 = Pbkdf2(

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -1,0 +1,242 @@
+import 'dart:convert';
+import 'dart:math';
+import 'package:convert/convert.dart';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:cryptography/cryptography.dart';
+import 'HomePages.dart';
+import 'SplashScreen.dart';
+
+Future<bool> _registerPIN(String pin) async {
+  /*SharedPreferences prefs = await SharedPreferences.getInstance();
+
+  // this should give us 256 bits? someone check my math
+  final SecretKey randKey = SecretKey(
+      List<int>.generate(32, (index) => Random.secure().nextInt(255)));
+  final randKeyBytesHexStr = hex.encode(await randKey.extractBytes());
+  // TODO create sqflite_sqlcipher here with randKeyBytesHexStr
+
+  // utf8 or ascii here? I guess utf8 gives us a bigger PIN space?
+  final SecretKey pinBytes = SecretKey(utf8.encode(pin));
+
+  final pbkdf2 = Pbkdf2(
+    macAlgorithm: Hmac.sha512(),
+    // iterations has to be at least 100000 for reasonable security. we can adjust later based on time data
+    iterations: 200000,
+    bits: 256,
+  );
+
+  // NIST standards say that the salt should be at least 16 bytes
+  final SecretKey salt = SecretKey(List<int>.filled(16, 0));
+  prefs.setString("salt", hex.encode(await salt.extractBytes()));
+
+  final userKey = await pbkdf2.deriveKey(
+    secretKey: pinBytes,
+    nonce: await salt.extractBytes(),
+  );
+
+  final sha512 = Sha512();
+  final hashedUserKey = await sha512.hash(await userKey.extractBytes());
+  prefs.setString("hashedUserKey", hex.encode(hashedUserKey.bytes));
+
+  final aes256 = AesGcm.with256bits();
+  final aesNonce = aes256.newNonce();
+
+  final encryptedRandKey = await aes256.encrypt(
+    await randKey.extractBytes(),
+    secretKey: userKey,
+    nonce: aesNonce,
+  );
+  prefs.setString("randKeyCipherText", hex.encode(encryptedRandKey.cipherText));
+  prefs.setString("randKeyNonce", hex.encode(encryptedRandKey.nonce));
+  prefs.setString("randKeyMAC", hex.encode(encryptedRandKey.mac.bytes));*/
+
+  /* --------------------- */
+  // this section is simulating a user login. TESTING ONLY! REMOVE LATER!
+  /*String userEnteredPin = "test";
+
+  final loginKeyGen = Pbkdf2(
+    macAlgorithm: Hmac.sha512(),
+    iterations: 200000,
+    bits: 256,
+  );
+
+  final SecretKey loginPinBytes = SecretKey(utf8.encode(pin));
+
+  final String loginSaltString = prefs.getString("salt").toString();
+  final SecretKey loginSalt = SecretKey(hex.decode(loginSaltString));
+
+  final loginUserKey = await loginKeyGen.deriveKey(
+    secretKey: loginPinBytes,
+    nonce: await loginSalt.extractBytes(),
+  );
+
+  final loginSha512 = Sha512();
+  final loginHashedUserKey =
+      await loginSha512.hash(await loginUserKey.extractBytes());
+  final storedHashedUserKey = prefs.getString("hashedUserKey").toString();
+
+  assert(hex.encode(loginHashedUserKey.bytes).hashCode ==
+      storedHashedUserKey.hashCode);
+
+  final storedRandKeyCipherText =
+      hex.decode(prefs.getString("randKeyCipherText").toString());
+  final storedRandKeyNonce =
+      hex.decode(prefs.getString("randKeyNonce").toString());
+  final storedRandKeyMAC = hex.decode(prefs.getString("randKeyMAC").toString());
+
+  final storedBox = SecretBox(
+    storedRandKeyCipherText,
+    nonce: storedRandKeyNonce,
+    mac: Mac(storedRandKeyMAC),
+  );
+
+  final loginAES = AesGcm.with256bits();
+
+  final clearText = await loginAES.decrypt(storedBox, secretKey: loginUserKey);
+  final clearTextStr = hex.encode(clearText);
+  assert(clearTextStr.hashCode == randKeyBytesHexStr.hashCode);*/
+  /* --------------------- */
+
+  await Future.delayed(const Duration(seconds: 5));
+
+  return true;
+}
+
+class RegistrationLoadingPage extends StatefulWidget {
+  final String pin;
+
+  const RegistrationLoadingPage({Key? key, required this.pin})
+      : super(key: key);
+
+  @override
+  State<RegistrationLoadingPage> createState() =>
+      _RegistrationLoadingPageState();
+}
+
+class _RegistrationLoadingPageState extends State<RegistrationLoadingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: _registerPIN(widget.pin),
+      builder: (context, snapshot) {
+        if (snapshot.data == null) {
+          return const SplashScreen();
+        } else {
+          return const HomePages();
+        }
+      },
+    );
+  }
+}
+
+void _submitForm(GlobalKey<FormState> key, BuildContext context, String pin) {
+  if (key.currentState!.validate()) {
+    Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => RegistrationLoadingPage(pin: pin)),
+        (route) => false);
+  }
+}
+
+class RegistrationForm extends StatefulWidget {
+  const RegistrationForm({Key? key}) : super(key: key);
+
+  @override
+  State<RegistrationForm> createState() => _RegistrationFormState();
+}
+
+class _RegistrationFormState extends State<RegistrationForm> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _firstPIN = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const Text(
+              "Enter a PIN:",
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            TextFormField(
+              autocorrect: false,
+              enableSuggestions: false,
+              enableIMEPersonalizedLearning: false,
+              // enableInteractiveSelection: true, // should be true if obscureText = true
+              // maxLines: 1, // defaults to 1
+              obscureText:
+                  true, // also disables stupid shit like gif and emoji keyboard
+              controller: _firstPIN,
+              autofocus: true,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a PIN';
+                }
+                return null;
+              },
+              textInputAction: TextInputAction.next,
+
+              //keeping the input format stuff out for now; trusting people to not be dumbasses
+              /*inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9]')),
+              ],*/
+            ),
+            const Text("Confirm your PIN:",
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            TextFormField(
+              autocorrect: false,
+              enableSuggestions: false,
+              enableIMEPersonalizedLearning: false,
+              obscureText: true,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              textInputAction: TextInputAction.go,
+              validator: (value) {
+                if (value != _firstPIN.text) {
+                  return "PINs do not match!";
+                }
+                return null;
+              },
+              onFieldSubmitted: (value) {
+                _submitForm(_formKey, context, _firstPIN.text);
+              },
+            ),
+            ElevatedButton(
+              onPressed: () {
+                _submitForm(_formKey, context, _firstPIN.text);
+                /*if(_formKey.currentState!.validate()) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Processing data')),
+                  );
+                }*/
+              },
+              child: const Text('Submit'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class RegistrationPage extends StatefulWidget {
+  const RegistrationPage({Key? key}) : super(key: key);
+
+  @override
+  State<RegistrationPage> createState() => _RegistrationPageState();
+}
+
+class _RegistrationPageState extends State<RegistrationPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: RegistrationForm(),
+    );
+  }
+}

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -17,7 +17,7 @@ Future<Map> _calculateEncryptionValues(String pin) async {
   final SecretKey randKey = SecretKey(
       List<int>.generate(32, (index) => Random.secure().nextInt(255)));
   final List<int> randKeyBytes = await randKey.extractBytes();
-  values.putIfAbsent("randKey", () => randKeyBytes);
+  values["randKey"] = randKeyBytes;
 
   final SecretKey pinBytes = SecretKey(utf8.encode(pin));
 
@@ -30,7 +30,7 @@ Future<Map> _calculateEncryptionValues(String pin) async {
   final SecretKey salt = SecretKey(
       List<int>.generate(16, (index) => Random.secure().nextInt(255)));
   final String saltStr = hex.encode(await salt.extractBytes());
-  values.putIfAbsent("salt", () => saltStr);
+  values["salt"] = saltStr;
 
   final userKey = await pbkdf2.deriveKey(
     secretKey: pinBytes,
@@ -40,7 +40,7 @@ Future<Map> _calculateEncryptionValues(String pin) async {
   final sha512 = Sha512();
   final hashedUserKey = await sha512.hash(await userKey.extractBytes());
   final String hashedUserKeyStr = hex.encode(hashedUserKey.bytes);
-  values.putIfAbsent("hashedUserKey", () => hashedUserKeyStr);
+  values["hashedUserKey"] = hashedUserKeyStr;
 
   final aes256 = AesGcm.with256bits();
   final aesNonce = aes256.newNonce();
@@ -50,11 +50,9 @@ Future<Map> _calculateEncryptionValues(String pin) async {
     secretKey: userKey,
     nonce: aesNonce,
   );
-  values.putIfAbsent(
-      "randKeyCipherText", () => hex.encode(encryptedRandKey.cipherText));
-  values.putIfAbsent("randKeyNonce", () => hex.encode(encryptedRandKey.nonce));
-  values.putIfAbsent(
-      "randKeyMAC", () => hex.encode(encryptedRandKey.mac.bytes));
+  values["randKeyCipherText"] = hex.encode(encryptedRandKey.cipherText);
+  values["randKeyNonce"] = hex.encode(encryptedRandKey.nonce);
+  values["randKeyMAC"] = hex.encode(encryptedRandKey.mac.bytes);
 
   return values;
 }

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -128,86 +128,72 @@ class _RegistrationFormState extends State<RegistrationForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: _formKey,
-      child: Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            const Text(
-              "Enter a PIN:",
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            TextFormField(
-              autocorrect: false,
-              enableSuggestions: false,
-              enableIMEPersonalizedLearning: false,
-              // enableInteractiveSelection: true, // should be true if obscureText = true
-              // maxLines: 1, // defaults to 1
-              obscureText:
-                  true, // also disables stupid shit like gif and emoji keyboard
-              controller: _firstPIN,
-              autofocus: true,
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter a PIN';
-                }
-                return null;
-              },
-              textInputAction: TextInputAction.next,
+    return Scaffold(
+      body: Form(
+        key: _formKey,
+        child: Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                "Enter a PIN:",
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              TextFormField(
+                autocorrect: false,
+                enableSuggestions: false,
+                enableIMEPersonalizedLearning: false,
+                // enableInteractiveSelection: true, // should be true if obscureText = true
+                // maxLines: 1, // defaults to 1
+                obscureText:
+                    true, // also disables stupid shit like gif and emoji keyboard
+                controller: _firstPIN,
+                autofocus: true,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a PIN';
+                  }
+                  return null;
+                },
+                textInputAction: TextInputAction.next,
 
-              //keeping the input format stuff out for now; trusting people to not be dumbasses
-              /*inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9]')),
-              ],*/
-            ),
-            const Text("Confirm your PIN:",
-                style: TextStyle(fontWeight: FontWeight.bold)),
-            TextFormField(
-              autocorrect: false,
-              enableSuggestions: false,
-              enableIMEPersonalizedLearning: false,
-              obscureText: true,
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-              textInputAction: TextInputAction.go,
-              validator: (value) {
-                if (value != _firstPIN.text) {
-                  return "PINs do not match!";
-                }
-                return null;
-              },
-              onFieldSubmitted: (value) {
-                _submitRegistrationForm(_formKey, context, _firstPIN.text);
-              },
-            ),
-            ElevatedButton(
-              onPressed: () {
-                _submitRegistrationForm(_formKey, context, _firstPIN.text);
-              },
-              child: const Text('Submit'),
-            )
-          ],
+                //keeping the input format stuff out for now; trusting people to not be dumbasses
+                /*inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9]')),
+                ],*/
+              ),
+              const Text("Confirm your PIN:",
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              TextFormField(
+                autocorrect: false,
+                enableSuggestions: false,
+                enableIMEPersonalizedLearning: false,
+                obscureText: true,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                textInputAction: TextInputAction.go,
+                validator: (value) {
+                  if (value != _firstPIN.text) {
+                    return "PINs do not match!";
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (value) {
+                  _submitRegistrationForm(_formKey, context, _firstPIN.text);
+                },
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  _submitRegistrationForm(_formKey, context, _firstPIN.text);
+                },
+                child: const Text('Submit'),
+              )
+            ],
+          ),
         ),
       ),
-    );
-  }
-}
-
-class RegistrationPage extends StatefulWidget {
-  const RegistrationPage({Key? key}) : super(key: key);
-
-  @override
-  State<RegistrationPage> createState() => _RegistrationPageState();
-}
-
-class _RegistrationPageState extends State<RegistrationPage> {
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: RegistrationForm(),
     );
   }
 }

--- a/lib/pages/RegistrationForm.dart
+++ b/lib/pages/RegistrationForm.dart
@@ -188,11 +188,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
             ElevatedButton(
               onPressed: () {
                 _submitRegistrationForm(_formKey, context, _firstPIN.text);
-                /*if(_formKey.currentState!.validate()) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Processing data')),
-                  );
-                }*/
               },
               child: const Text('Submit'),
             )

--- a/lib/pages/SettingsTab.dart
+++ b/lib/pages/SettingsTab.dart
@@ -53,7 +53,7 @@ class _SettingsTabState extends State<SettingsTab> {
           onTap: () {
             Hive.close();
             Navigator.of(context).pushAndRemoveUntil(
-              MaterialPageRoute(builder: (_) => const LoginPage(isError: false)),
+              MaterialPageRoute(builder: (_) => const LoginForm(isError: false)),
               (route) => false,
             );
           },

--- a/lib/pages/SettingsTab.dart
+++ b/lib/pages/SettingsTab.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'LoginForm.dart';
 import '../models/SettingsItem.dart';
 import 'AboutPage.dart';
 import 'CanaryPage.dart';
@@ -18,20 +20,43 @@ class _SettingsTabState extends State<SettingsTab> {
   Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.all(10.0),
-      children: const [
-        SettingsItem(
+      children: [
+        const SettingsItem(
           settingName: "About",
           pagePath: AboutPage(),
         ),
-        Divider(thickness: 3),
-        SettingsItem(
+        const Divider(thickness: 3),
+        const SettingsItem(
           settingName: "Canary",
           pagePath: CanaryPage(),
         ),
-        Divider(thickness: 3),
-        SettingsItem(
+        const Divider(thickness: 3),
+        const SettingsItem(
           settingName: "Disclaimers",
           pagePath: DisclaimersPage(),
+        ),
+        const Divider(thickness: 3),
+        ListTile(
+          title: const Text(
+            "Logout",
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w500,
+              color: Colors.red,
+            ),
+          ),
+          trailing: const Icon(
+            Icons.arrow_forward_ios,
+            color: Colors.red,
+            semanticLabel: 'Select',
+          ),
+          onTap: () {
+            Hive.close();
+            Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(builder: (_) => const LoginPage(isError: false)),
+              (route) => false,
+            );
+          },
         ),
         Divider(thickness: 3),
       ],

--- a/lib/pages/SplashScreen.dart
+++ b/lib/pages/SplashScreen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SizedBox.expand(
+        child: Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Colors.red, Colors.black],
+              begin: Alignment.bottomLeft,
+              end: Alignment.topRight,
+            ),
+          ),
+          child: Center(
+            child: Text( // TODO replace with logo
+              "yours",
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontStyle: FontStyle.italic,
+                fontSize: DefaultTextStyle.of(context).style.apply(fontSizeFactor: 2.0).fontSize,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/SplashScreen.dart
+++ b/lib/pages/SplashScreen.dart
@@ -1,5 +1,32 @@
 import 'package:flutter/material.dart';
 
+class LoadingPage extends StatefulWidget {
+  final Future<dynamic> Function() future;
+  final Widget Function(Object) handleFinished;
+
+  const LoadingPage(
+      {Key? key, required this.future, required this.handleFinished})
+      : super(key: key);
+
+  @override
+  State<LoadingPage> createState() => _LoadingState();
+}
+
+class _LoadingState extends State<LoadingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+        future: widget.future(),
+        builder: (context, snapshot) {
+          if (snapshot.data == null) {
+            return const SplashScreen();
+          } else {
+            return widget.handleFinished(snapshot.data!);
+          }
+        });
+  }
+}
+
 class SplashScreen extends StatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);
 
@@ -21,13 +48,17 @@ class _SplashScreenState extends State<SplashScreen> {
             ),
           ),
           child: Center(
-            child: Text( // TODO replace with logo
+            child: Text(
+              // TODO replace with logo
               "yours",
               style: TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.bold,
                 fontStyle: FontStyle.italic,
-                fontSize: DefaultTextStyle.of(context).style.apply(fontSizeFactor: 2.0).fontSize,
+                fontSize: DefaultTextStyle.of(context)
+                    .style
+                    .apply(fontSizeFactor: 2.0)
+                    .fontSize,
               ),
             ),
           ),

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_macos
 import shared_preferences_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,40 @@
+platform :osx, '10.11'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  dots_indicator:
+    dependency: transitive
+    description:
+      name: dots_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -57,6 +64,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -74,6 +95,25 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  introduction_screen:
+    dependency: "direct main"
+    description:
+      name: introduction_screen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -109,6 +149,104 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.7"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.4"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.15"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.12"
+  shared_preferences_ios:
+    dependency: transitive
+    description:
+      name: shared_preferences_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -163,5 +301,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.7.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0+1"
 sdks:
   dart: ">=2.17.5 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
+  convert:
+    dependency: "direct main"
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -78,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -294,6 +322,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -128,6 +128,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.3"
   introduction_screen:
     dependency: "direct main"
     description:
@@ -177,6 +184,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.16"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.10"
   path_provider_linux:
     dependency: transitive
     description:
@@ -184,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  introduction_screen: ^3.0.2
+  shared_preferences: ^2.0.15
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   introduction_screen: ^3.0.2
   shared_preferences: ^2.0.15
+  cryptography: ^2.0.5
+  convert: ^3.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   shared_preferences: ^2.0.15
   cryptography: ^2.0.5
   convert: ^3.0.2
+  hive: ^2.2.3
+  path_provider: ^2.0.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added onboarding page. Navigate to onboarding page if user not "onboarded" before. Go to login page otherwise.

Added registration page after onboarding. Takes user PIN, performs mathy stuff, stores the results so we can unlock the database in the future if and only if the user provides the same PIN again.

Login repeats that mathy stuff to validate the PIN, then passes the unlocked DB if so.

Logout closes the DB, then navigates back to login.

Registration and login show the splash page while doing intensive mathy stuff.